### PR TITLE
support adding custom options to named.conf.options

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -379,6 +379,22 @@ still uses the old key.
 
 Default value: ``true``
 
+##### `custom_options`
+
+Data type: `Hash[String, String]`
+
+Custom options to be added to /etc/bind/named.conf.options.
+The following format is expected:
+
+```
+custom_options => {
+  'option1' => 'value1',
+  'option2' => 'value2',
+}
+```
+
+Default value: ``{}``
+
 ##### `report_hostname`
 
 Data type: `Optional[String]`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,9 +228,11 @@ class bind (
   Stdlib::Ensure::Service $service_ensure             = 'running',
   Boolean                 $service_enable             = true,
   Boolean                 $manage_rndc_keyfile        = true,
+  Hash[String, String]    $custom_options             = {},
   Optional[String]        $report_hostname            = undef,
   Optional[String]        $report_version             = undef,
   Optional[Boolean]       $querylog_enable            = undef,
+
 ) {
 
   $header_message = '// This file is managed by Puppet. DO NOT EDIT.'
@@ -417,6 +419,7 @@ class bind (
     'querylog_enable'    => $querylog_enable,
     'dnssec_enable'      => $dnssec_enable,
     'empty_zones_enable' => $empty_zones_enable,
+    'custom_options'     => $custom_options,
   }
 
   concat { 'named.conf.options':

--- a/templates/options.main.epp
+++ b/templates/options.main.epp
@@ -60,3 +60,7 @@
 
   empty-zones-enable <%= bool2str($empty_zones_enable, 'yes', 'no') -%>;
 <% } -%>
+
+<% $custom_options.each |$option, $value| { -%>
+  <%= $option %> <%= $value %>;
+<% } -%>


### PR DESCRIPTION
Makes it possible to add configurations currently not supported by the module.

