### PR TITLE
support views in zonefile paths

### DIFF
--- a/functions/zonefile_path.pp
+++ b/functions/zonefile_path.pp
@@ -14,7 +14,7 @@
 #   The relative path and filename where the zonefile should be stored.
 #   Example: 'com/example/db.example.com_internal'
 #
-function bind::zonefile_path(String $zone, String $view = '') >> String {
+function bind::zonefile_path(String $zone, Optional[String] $view = '') >> String {
   $names = split($zone, '[.]')
 
   if (length($names) > 1) {
@@ -32,7 +32,7 @@ function bind::zonefile_path(String $zone, String $view = '') >> String {
     $part = $zone
   }
 
-  if (length($view) > 0 ) {
+  if ($view and length($view) > 0 ) {
     $viewpart = "_${view}"
   } else {
     $viewpart = ''

--- a/functions/zonefile_path.pp
+++ b/functions/zonefile_path.pp
@@ -6,11 +6,15 @@
 #   The name of the zone for which the path should be returned.  Example:
 #   'example.com'
 #
+# @param view Optional[String]
+#   The name of the view for which the path should be returned.  Example:
+#   'internal'
+#
 # @return [String]
 #   The relative path and filename where the zonefile should be stored.
-#   Example: 'com/example/db.example.com'
+#   Example: 'com/example/db.example.com_internal'
 #
-function bind::zonefile_path(String $zone) >> String {
+function bind::zonefile_path(String $zone, String $view = '') >> String {
   $names = split($zone, '[.]')
 
   if (length($names) > 1) {
@@ -28,5 +32,11 @@ function bind::zonefile_path(String $zone) >> String {
     $part = $zone
   }
 
-  "${dir}/db.${part}"
+  if (length($view) > 0 ) {
+    $viewpart = "_${view}"
+  } else {
+    $viewpart = ''
+  }
+
+  "${dir}/db.${part}${viewpart}"
 }

--- a/manifests/zone/primary.pp
+++ b/manifests/zone/primary.pp
@@ -107,6 +107,10 @@
 # @param comment
 #   A comment to add to the zone file.
 #
+# @param append_view
+#   Should the view name be appended to the name of the zonefile.
+#   Only valid when 'view' is set
+#
 # @param zone
 #   The name of the zone.
 #
@@ -136,6 +140,7 @@ define bind::zone::primary (
   Optional[String]                     $content                   = undef,
   Optional[Boolean]                    $zone_statistics           = undef,
   Optional[String]                     $comment                   = undef,
+  Optional[Boolean]                    $append_view               = undef,
   String                               $zone                      = $name,
   Bind::Zone::Class                    $class                     = 'IN',
   String                               $order                     = '20',
@@ -151,7 +156,11 @@ define bind::zone::primary (
     $zonefile = $file
   }
   else {
-    $zonepath = bind::zonefile_path($zone)
+    if ($append_view) {
+      $zonepath = bind::zonefile_path($zone, $view)
+    } else {
+      $zonepath = bind::zonefile_path($zone)
+    }
     $zonefile = "${zonebase}/${zonepath}"
 
     $zonedir1 = dirname($zonefile)

--- a/manifests/zone/secondary.pp
+++ b/manifests/zone/secondary.pp
@@ -25,6 +25,10 @@
 # @param comment
 #   A comment to add to the zone file.
 #
+# @param append_view
+#   Should the view name be appended to the name of the zonefile.
+#   Only valid when 'view' is set
+#
 # @param zone
 #   The name of the zone.
 #
@@ -41,6 +45,7 @@ define bind::zone::secondary (
   Optional[Boolean] $zone_statistics = undef,
   Optional[Boolean] $multi_master    = undef,
   Optional[String]  $comment         = undef,
+  Optional[Boolean]                    $append_view               = undef,
   String            $zone            = $name,
   Bind::Zone::Class $class           = 'IN',
   String            $order           = '30',
@@ -51,7 +56,11 @@ define bind::zone::secondary (
   }
 
   $zonebase = "${bind::vardir}/secondary"
-  $zonepath = bind::zonefile_path($zone)
+  if ($append_view) {
+    $zonepath = bind::zonefile_path($zone, $view)
+  } else {
+    $zonepath = bind::zonefile_path($zone)
+  }
   $zonefile = "${zonebase}/${zonepath}"
 
   $zonedir1 = dirname($zonefile)

--- a/spec/functions/zonefile_path_spec.rb
+++ b/spec/functions/zonefile_path_spec.rb
@@ -13,6 +13,12 @@ describe 'bind::zonefile_path' do
     }
   end
 
+  context 'with zone => foo.local and view => internal' do
+    it {
+      is_expected.to run.with_params('foo.local', 'internal').and_return('local/foo/db.foo.local_internal')
+    }
+  end
+
   context 'with zone => foo.bar.local' do
     it {
       is_expected.to run.with_params('foo.bar.local').and_return('local/bar/db.foo.bar.local')
@@ -34,6 +40,12 @@ describe 'bind::zonefile_path' do
   context 'with zone => 12.11.10.in-addr.arpa' do
     it {
       is_expected.to run.with_params('12.11.10.in-addr.arpa').and_return('arpa/in-addr/db.10.11.12')
+    }
+  end
+
+  context 'with zone => 12.11.10.in-addr.arpa and view => internal' do
+    it {
+      is_expected.to run.with_params('12.11.10.in-addr.arpa', 'internal').and_return('arpa/in-addr/db.10.11.12_internal')
     }
   end
 end

--- a/spec/functions/zonefile_path_spec.rb
+++ b/spec/functions/zonefile_path_spec.rb
@@ -13,6 +13,12 @@ describe 'bind::zonefile_path' do
     }
   end
 
+  context 'with zone => foo.local and view => undef' do
+    it {
+      is_expected.to run.with_params('foo.local', :undef).and_return('local/foo/db.foo.local')
+    }
+  end
+
   context 'with zone => foo.local and view => internal' do
     it {
       is_expected.to run.with_params('foo.local', 'internal').and_return('local/foo/db.foo.local_internal')


### PR DESCRIPTION
Fixes #8 by adding a param "append_view" to primary and secondary zones.
When present and param "view" is also set, the generated zonefile will be named <zone>_<view>