### PR TITLE
Per-zone allow transfer and custom view options

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,30 @@ bind::views:
 
 The defined types `bind::zone::primary` and `bind::zone::secondary` can be used to add zones to this view.
 
+Global options that are not modeled as dedicated class parameters can be
+set with `custom_options`. 
+
+```puppet
+class { 'bind':
+  custom_options => {
+    'minimal-responses' => 'no-auth-recursive',
+  },
+}
+```
+
+The `bind::view` defined type supports the same pattern for per-view options:
+
+```puppet
+bind::view { 'internal':
+  match_clients   => [ 'localnets', ],
+  allow_query     => [ 'localnets', ],
+  allow_recursion => [ 'localnets', ],
+  custom_options  => {
+    'minimal-responses' => true,
+  },
+}
+```
+
 ## Reference
 
 See [REFERENCE.md](https://github.com/smoeding/puppet-bind/blob/master/REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1997,6 +1997,7 @@ The following parameters are available in the `bind::view` defined type:
 * [`view`](#-bind--view--view)
 * [`order`](#-bind--view--order)
 * [`response_policies`](#-bind--view--response_policies)
+* [`custom_options`](#-bind--view--custom_options)
 
 ##### <a name="-bind--view--match_clients"></a>`match_clients`
 
@@ -2155,6 +2156,19 @@ Data type: `Array[String]`
 An array of response policy zones.
 
 Default value: `[]`
+
+##### <a name="-bind--view--custom_options"></a>`custom_options`
+
+Data type: `Hash[String,Data]`
+
+Additional config options that are not implemented as parameters of this
+defined type can be set by a hash of custom options. Each key of the hash
+will be added to the view block of the configuration. For string or numeric
+values the value will be added as a normal option value. If the value is a
+hash or an array it will be included as an additional block enclosed in
+braces.
+
+Default value: `{}`
 
 ### <a name="bind--zone--forward"></a>`bind::zone::forward`
 
@@ -3392,3 +3406,4 @@ Alias of `Enum['critical', 'error', 'warning', 'notice', 'info', 'debug', 'dynam
 Type to match allowed values for the zone class
 
 Alias of `Enum['IN', 'HS', 'CH']`
+

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2472,6 +2472,16 @@ bind::zone::primary { 'example.com':
 }
 ```
 
+##### Restrict zone transfers for a primary zone
+
+```puppet
+
+bind::zone::primary { 'example.com':
+  source         => 'puppet:///modules/profile/example.com.zone',
+  allow_transfer => ['192.0.2.42'],
+}
+```
+
 ##### Use DNSSEC signing for a primary zone using a DNSSEC policy
 
 ```puppet
@@ -2499,6 +2509,7 @@ bind::zone::primary { '_acme-challenge.example.com':
 The following parameters are available in the `bind::zone::primary` defined type:
 
 * [`also_notify`](#-bind--zone--primary--also_notify)
+* [`allow_transfer`](#-bind--zone--primary--allow_transfer)
 * [`update_policy`](#-bind--zone--primary--update_policy)
 * [`dnssec_enable`](#-bind--zone--primary--dnssec_enable)
 * [`dnssec_dnskey_kskonly`](#-bind--zone--primary--dnssec_dnskey_kskonly)
@@ -2527,6 +2538,15 @@ Data type: `Array[String]`
 
 Secondary servers that should be notified in addition to the
 nameservers that are listed in the zone file.
+
+Default value: `[]`
+
+##### <a name="-bind--zone--primary--allow_transfer"></a>`allow_transfer`
+
+Data type: `Array[String]`
+
+An array of ACL names or networks that are allowed to transfer zone
+information for this zone.
 
 Default value: `[]`
 
@@ -3372,4 +3392,3 @@ Alias of `Enum['critical', 'error', 'warning', 'notice', 'info', 'debug', 'dynam
 Type to match allowed values for the zone class
 
 Alias of `Enum['IN', 'HS', 'CH']`
-

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -75,6 +75,14 @@
 # @param response_policies
 #   An array of response policy zones.
 #
+# @param custom_options
+#   Additional config options that are not implemented as parameters of this
+#   defined type can be set by a hash of custom options. Each key of the hash
+#   will be added to the view block of the configuration. For string or numeric
+#   values the value will be added as a normal option value. If the value is a
+#   hash or an array it will be included as an additional block enclosed in
+#   braces.
+#
 #
 define bind::view (
   Array[String]     $match_clients            = ['any',],
@@ -93,6 +101,7 @@ define bind::view (
   String            $view                     = $name,
   String            $order                    = '10',
   Array[String]     $response_policies        = [],
+  Hash[String,Data] $custom_options           = {},
   Optional[Boolean] $localhost_forward_enable = undef,
   Optional[Boolean] $localhost_reverse_enable = undef,
 ) {
@@ -120,6 +129,7 @@ define bind::view (
     'allow_query_cache_on' => $allow_query_cache_on,
     'allow_transfer'       => $allow_transfer,
     'response_policies'    => $response_policies,
+    'custom_options'       => bind::gencfg($custom_options, 2),
   }
 
   concat::fragment { "named.conf.views-${view}-00":

--- a/manifests/zone/primary.pp
+++ b/manifests/zone/primary.pp
@@ -13,6 +13,13 @@
 #     source => 'puppet:///modules/profile/example.com.zone',
 #   }
 #
+# @example Restrict zone transfers for a primary zone
+#
+#   bind::zone::primary { 'example.com':
+#     source         => 'puppet:///modules/profile/example.com.zone',
+#     allow_transfer => ['192.0.2.42'],
+#   }
+#
 # @example Use DNSSEC signing for a primary zone using a DNSSEC policy
 #
 #   bind::zone::primary { 'example.com':
@@ -32,6 +39,10 @@
 # @param also_notify
 #   Secondary servers that should be notified in addition to the
 #   nameservers that are listed in the zone file.
+#
+# @param allow_transfer
+#   An array of ACL names or networks that are allowed to transfer zone
+#   information for this zone.
 #
 # @param update_policy
 #   Enable dynamic updates for the zone and define the update policy. This
@@ -124,6 +135,7 @@
 #
 define bind::zone::primary (
   Array[String]                        $also_notify               = [],
+  Array[String]                        $allow_transfer            = [],
   Variant[Enum['local'],Array[String]] $update_policy             = [],
   Optional[Boolean]                    $dnssec_enable             = undef,
   Optional[Boolean]                    $dnssec_dnskey_kskonly     = undef,
@@ -257,17 +269,18 @@ define bind::zone::primary (
   }
 
   $params = {
-    'zone'          => $zone,
-    'file'          => $zonefile,
-    'also_notify'   => $also_notify,
-    'notify'        => $notify_secondaries,
-    'statistics'    => $zone_statistics,
-    'update_policy' => $update_policy,
-    'class'         => $class,
-    'comment'       => $comment,
-    'indent'        => bool2str($bind::views_enable, '  ', ''),
-    'zone_in_view'  => ($view =~ NotUndef),
-    'dnssec_params' => !empty(delete_undef_values($params_dnssec)),
+    'zone'           => $zone,
+    'file'           => $zonefile,
+    'also_notify'    => $also_notify,
+    'allow_transfer' => $allow_transfer,
+    'notify'         => $notify_secondaries,
+    'statistics'     => $zone_statistics,
+    'update_policy'  => $update_policy,
+    'class'          => $class,
+    'comment'        => $comment,
+    'indent'         => bool2str($bind::views_enable, '  ', ''),
+    'zone_in_view'   => ($view =~ NotUndef),
+    'dnssec_params'  => !empty(delete_undef_values($params_dnssec)),
   }
 
   if $bind::views_enable {

--- a/spec/defines/view_spec.rb
+++ b/spec/defines/view_spec.rb
@@ -205,6 +205,48 @@ describe 'bind::view' do
         }
       end
 
+      context 'with custom_options => { "minimal-responses" => true }' do
+        let(:params) do
+          { custom_options: { 'minimal-responses' => true } }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('named.conf.views-internal-00')
+            .with_target('named.conf.views')
+            .with_content("\nview \"internal\" {\n  match-clients {\n    any;\n  };\n\n  allow-query {\n    any;\n  };\n\n  recursion yes;\n\n  minimal-responses yes;\n")
+            .with_order('10')
+
+          is_expected.to contain_concat__fragment('named.conf.views-internal-99')
+            .with_content('};')
+        }
+      end
+
+      context 'with custom_options => { "minimal-responses" => "no-auth-recursive" }' do
+        let(:params) do
+          { custom_options: { 'minimal-responses' => 'no-auth-recursive' } }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('named.conf.views-internal-00')
+            .with_target('named.conf.views')
+            .with_content("\nview \"internal\" {\n  match-clients {\n    any;\n  };\n\n  allow-query {\n    any;\n  };\n\n  recursion yes;\n\n  minimal-responses no-auth-recursive;\n")
+            .with_order('10')
+        }
+      end
+
+      context 'with custom_options => { "sortlist" => ["localnets", "localhost"] }' do
+        let(:params) do
+          { custom_options: { 'sortlist' => ['localnets', 'localhost'] } }
+        end
+
+        it {
+          is_expected.to contain_concat__fragment('named.conf.views-internal-00')
+            .with_target('named.conf.views')
+            .with_content("\nview \"internal\" {\n  match-clients {\n    any;\n  };\n\n  allow-query {\n    any;\n  };\n\n  recursion yes;\n\n  sortlist {\n    localnets;\n    localhost;\n  };\n")
+            .with_order('10')
+        }
+      end
+
       context 'with root_hints_enable => true' do
         let(:params) do
           { root_hints_enable: true }

--- a/spec/defines/zone/primary_spec.rb
+++ b/spec/defines/zone/primary_spec.rb
@@ -375,6 +375,44 @@ describe 'bind::zone::primary' do
         }
       end
 
+      context 'with source => "/file", allow_transfer => ["any"]' do
+        let(:params) do
+          { source: '/file', allow_transfer: ['any'] }
+        end
+
+        it {
+          is_expected.to contain_file('/var/lib/bind/primary/com')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example/db.example.com')
+
+          is_expected.to contain_exec('bind::reload::example.com')
+
+          is_expected.to contain_concat__fragment('named.conf.zones-example.com')
+            .with_target('named.conf.zones')
+            .with_order('20')
+            .with_content(%r{allow-transfer {\n\s+any;\n\s+};})
+        }
+      end
+
+      context 'with source => "/file", allow_transfer => ["acl1", "192.0.2.42"]' do
+        let(:params) do
+          { source: '/file', allow_transfer: ['acl1', '192.0.2.42'] }
+        end
+
+        it {
+          is_expected.to contain_file('/var/lib/bind/primary/com')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example/db.example.com')
+
+          is_expected.to contain_exec('bind::reload::example.com')
+
+          is_expected.to contain_concat__fragment('named.conf.zones-example.com')
+            .with_target('named.conf.zones')
+            .with_order('20')
+            .with_content(%r{allow-transfer {\n\s+acl1;\n\s+192.0.2.42;\n\s+};})
+        }
+      end
+
       context 'with source => "/file", zone_statistics => true' do
         let(:params) do
           { source: '/file', zone_statistics: true }
@@ -812,6 +850,25 @@ describe 'bind::zone::primary' do
             .with_target('named.conf.views')
             .with_order('10')
             .with_content(%r{also-notify {\n  \s+192.0.2.42;\n  \s+};})
+        }
+      end
+
+      context 'with view => "internal", source => "/file", allow_transfer => ["any"]' do
+        let(:params) do
+          { view: 'internal', source: '/file', allow_transfer: ['any'] }
+        end
+
+        it {
+          is_expected.to contain_file('/var/lib/bind/primary/com')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example')
+          is_expected.to contain_file('/var/lib/bind/primary/com/example/db.example.com')
+
+          is_expected.to contain_exec('bind::reload::internal::example.com')
+
+          is_expected.to contain_concat__fragment('named.conf.views-internal-50-example.com')
+            .with_target('named.conf.views')
+            .with_order('10')
+            .with_content(%r{allow-transfer {\n  \s+any;\n  \s+};})
         }
       end
 

--- a/templates/view.epp
+++ b/templates/view.epp
@@ -83,3 +83,7 @@ view "<%= $view -%>" {
 <%   } -%>
   };
 <% } -%>
+<% unless empty($custom_options) { -%>
+
+<%= $custom_options -%>
+<% } -%>

--- a/templates/zone-primary.epp
+++ b/templates/zone-primary.epp
@@ -29,6 +29,14 @@
 <% } -%>
 <%= $indent %>  };
 <% } -%>
+<% unless empty($allow_transfer) { -%>
+
+<%= $indent %>  allow-transfer {
+<% $allow_transfer.each |$item| { -%>
+<%= $indent %>    <%= $item -%>;
+<% } -%>
+<%= $indent %>  };
+<% } -%>
 <% if $dnssec_params { -%>
 
 <% if $dnssec_enable =~ NotUndef { -%>


### PR DESCRIPTION
Added support for allow_transfer on primary zones, so transfer settings can now be handled directly as part of the zone definition.

Added support for custom_options in bind::view, making it possible to render view-level options such as minimal-responses without introducing a dedicated parameter for each case.